### PR TITLE
Create 2017-08-03-europe-tops-6gw-windeurope

### DIFF
--- a/_posts/2017-08-03-europe-tops-6gw-windeurope
+++ b/_posts/2017-08-03-europe-tops-6gw-windeurope
@@ -1,0 +1,32 @@
+---
+title: New wind energy capacity rolled out across Europe in 1H17 tops 6 GW
+date: 2017-08-03T15:00:00Z
+categories:
+- wind energy
+- general
+- no-cita
+layout: blog
+featured-img-url: world_map.png
+featured-img-alt: Europe adds 6.1 GW of new wind capacity
+meta: Europe adds 6.1 GW of new wind capacity
+excerpt: According to WindEurope, 6.1 GW of new capacity was added, which points towards 2017 being a great year for installations. 
+author: vortex
+keywords: 'vortex, WindEurope, Wind Energy, Europe'
+---
+
+
+
+## New wind energy capacity rolled out across Europe in 1H17 tops 6 GW
+WindEurope has published figures for new wind energy capacity installed during the first half of 2017. According to the European wind energy association, 6.1 GW of new capacity was added, which points towards 2017 being a great year for installations. The association does however warn that the figures hide some worrying trends: excessive concentration in a few markets and a decline in finance.
+ 
+Of the total 6.1 GW installed across Europe, **4.8 GW was onshore, heavily concentrated in Germany (2.2 GW), the UK (1.2 GW) and France (492 MW)**. A raft of offshore wind projects also saw a total of 1.3 GW installed. In monetary terms, the new capacity was rolled out at a cost of €8.3 billion.
+
+## WindEurope has positive prospects for wind energy capacity growth in 2017
+
+**“We are on track for a good year… but growth is driven by a handful of markets,”** said WindEurope Chief Policy Officer, Pierre Tardieu. “At least ten EU countries having yet to install a single MW so far this year. On onshore wind, the end of UK Renewable Obligation scheme **will lead to even greater market concentration in Germany, Spain and France**”.
+ 
+Tardieu pointed out that the level of finance for onshore projects is also a concern, although this will not impact on rollouts of new capacity for another few years. “The industry needs clarity on volumes for the post-2020 period to maintain the current cost reduction trend,” Tardieu added. “Member States should come forward as soon as possible with their National Energy and Climate Plans to 2030. In combination with the three-year auctioning schedule proposed by the European Commission, the national plans will give sorely needed visibility to the wind energy supply chain”.
+
+The full mid-year statistics report from WindEurope including a mid-term outlook to 2020 and a dedicated webinar will be launched in the second half of September 2017.
+
+SOURCE: <a href="https://windeurope.org/newsroom/europe-adds-6-1-gw-wind-energy-capacity-first-half-2017" target="_blank">WindEurope</a>


### PR DESCRIPTION
Nova notícia pel blog "**New wind energy capacity rolled out across Europe in 1H17 tops 6 GW**"

Falta pujar foto principal:

![wind-energy-6gw-europe](https://user-images.githubusercontent.com/30494856/28925967-aba413d4-7866-11e7-86a8-2986c50af20d.jpg)
